### PR TITLE
Retrigger workflow on new push to branch with PR open

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -2,7 +2,7 @@ name: Test pull request
 
 on:
   pull_request:
-    types: [opened, reopened, review_requested]
+    types: [opened, reopened, review_requested, synchronize]
     paths:
       - "Dockerfile/**"
 


### PR DESCRIPTION
`Test pull request` only runs once when a PR is opened, but it should run again when additional changes to `Dockerfile/**` are pushed to the branch.