### PR TITLE
Fix syntax

### DIFF
--- a/Dockerfile/full-ubuntu-amd64
+++ b/Dockerfile/full-ubuntu-amd64
@@ -27,7 +27,7 @@ RUN npm install -g aws-azure-login --unsafe-perm \
 # Install terraform-docs
 RUN export tfdocsrelease="$(curl -s 'https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest' | jq -r '.tag_name')" \
   && go install github.com/terraform-docs/terraform-docs@${tfdocsrelease} \
-  && export PATH="$PATH:/root/go/bin"
+  && echo "export PATH=${PATH}:/root/go/bin" >> /root/.bashrc
 
 # Install checkov
 RUN export checkovrelease="$(curl -s 'https://api.github.com/repos/bridgecrewio/checkov/releases/latest' | jq -r '.tag_name')" \


### PR DESCRIPTION
The `PATH` wasn't being updated properly in the non-interactive shell using my previous syntax, which worked when running the commands interactively. This fix has been tested as follows:

```
docker run -it ghcr.io/slalombuild/pe-toolkit-full-ubuntu-amd64
root@55e3e4cdc4e0:/# echo "export PATH=${PATH}:/root/go/bin" >> /root/.bashrc

# Separate shell, with above process still running
± |feature/add-more-tools ✓| → docker ps
CONTAINER ID   IMAGE                                              COMMAND       CREATED         STATUS         PORTS     NAMES
55e3e4cdc4e0   ghcr.io/slalombuild/pe-toolkit-full-ubuntu-amd64   "/bin/bash"   7 seconds ago   Up 6 seconds             angry_chaum

[2023-02-14 12:24] [py-'python'] vanastassiou @ DESKTOP-J3KG02K in ~/repos/v-stuff/platform-engineering-toolkit/Dockerfile
± |feature/add-more-tools ✓| → docker commit 55e3e4cdc4e0 pe:working
sha256:135589f4b9df19942d2138d114f66ee077c722a844472aef13bb1209a408c5a2

# The other shell running the container may now be closed

[2023-02-14 12:25] [py-'python'] vanastassiou @ DESKTOP-J3KG02K in ~/repos/v-stuff/platform-engineering-toolkit/Dockerfile
± |feature/add-more-tools ✓| → docker run -it pe:working

root@6c225ce61342:/# env | grep go
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/go/bin
root@6c225ce61342:/# terraform-docs --version
terraform-docs version v0.16.0 linux/amd64
```