### PR TITLE
Added opa and tests

### DIFF
--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   standard-alpine:
-    name: standard-alpine-amd64
+    name: Build and publish standard-alpine-amd64
     runs-on: ubuntu-latest
 
     steps:
@@ -56,10 +56,11 @@ jobs:
 
   tests:
     name: Test standard-alpine-amd64
-    runs-on: standard-alpine-amd64:1.0.${{ github.run_number }}
+    runs-on: standard-alpine-amd64:${{ github.sha }}
     needs: standard-alpine
+    if: ${{ success() }}
     steps:
-      - name: Tests
+      - name: Run each tool
         run: |
           terraform version
           atmos version

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -3,7 +3,7 @@ name: Docker Build and Publish
 on:
   workflow_dispatch:
   push:
-    # branches: ["main"]
+    branches: ["main"]
     paths:
       - "images/**"
   schedule:

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -168,7 +168,7 @@ jobs:
     name: Test standard-alpine-amd64
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/slalombuild/standard-alpine-amd64:1.0.${{ github.run_number }}
+      image: ghcr.io/slalombuild/pe-toolkit-standard-alpine-amd64 :1.0.${{ github.run_number }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -183,15 +183,53 @@ jobs:
           tfsec --version
           opa version
 
+  test-full-alpine:
+    name: Test full-alpine-amd64
+    runs-on: alpine-latest
+    container:
+      image: ghcr.io/slalombuild/pe-toolkit-full-alpine-amd64:1.0.${{ github.run_number }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    needs: full-alpine
+    if: ${{ success() }}
+    steps:
+      - name: Run each tool
+        run: |
+          terraform version
+          atmos version
+          tflint --version
+          tfsec --version
+          opa version
+
   test-standard-ubuntu:
     name: Test standard-ubuntu-amd64
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/slalombuild/standard-ubuntu-amd64:1.0.${{ github.run_number }}
+      image: ghcr.io/slalombuild/pe-toolkit-standard-ubuntu-amd64:1.0.${{ github.run_number }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     needs: standard-ubuntu
+    if: ${{ success() }}
+    steps:
+      - name: Run each tool
+        run: |
+          terraform version
+          atmos version
+          tflint --version
+          tfsec --version
+          opa version
+
+  test-full-ubuntu:
+    name: Test full-ubuntu-amd64
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/slalombuild/pe-toolkit-full-ubuntu-amd64:1.0.${{ github.run_number }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    needs: full-ubuntu
     if: ${{ success() }}
     steps:
       - name: Run each tool

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -56,7 +56,7 @@ jobs:
 
   tests:
     name: Test standard-alpine-amd64
-    runs-on: standard-alpine-amd64:${{ github.sha }}
+    runs-on: standard-alpine-amd64:1.0.${{ github.run_number }}
     needs: standard-alpine
     steps:
       - name: Tests

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -56,7 +56,7 @@ jobs:
 
   tests:
     name: Test standard-alpine-amd64
-    runs-on: ghcr.io/slalombuild/standard-alpine-amd64:${{ github.sha }}
+    runs-on: standard-alpine-amd64:${{ env.IMAGE_TAG }}
     needs: standard-alpine
     if: ${{ success() }}
     steps:

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -57,6 +57,7 @@ jobs:
   tests:
     name: Test standard-alpine-amd64
     runs-on: standard-alpine-amd64:${{ github.sha }}
+    needs: standard-alpine
     steps:
       - name: Tests
         run: |

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   standard-alpine:
-    name: Build and publish standard-alpine-amd64
+    name: Build standard-alpine-amd64
     runs-on: ubuntu-latest
 
     steps:
@@ -52,10 +52,11 @@ jobs:
           registry: ghcr.io
           buildoptions: "--compress --force-rm"
           dockerfile: images/standard-alpine-amd64/Dockerfile
+          platforms: linux/amd64
           tags: "latest,${{ env.IMAGE_TAG }}"
 
   standard-ubuntu:
-    name: standard-ubuntu-amd64
+    name: Build standard-ubuntu-amd64
     runs-on: ubuntu-latest
 
     steps:
@@ -88,10 +89,11 @@ jobs:
           registry: ghcr.io
           buildoptions: "--compress --force-rm"
           dockerfile: images/standard-ubuntu-amd64/Dockerfile
+          platforms: linux/amd64
           tags: "latest,${{ env.IMAGE_TAG }}"
 
   full-alpine:
-    name: full-alpine-amd64
+    name: Build full-alpine-amd64
     runs-on: ubuntu-latest
 
     steps:
@@ -123,10 +125,11 @@ jobs:
           registry: ghcr.io
           buildoptions: "--compress --force-rm"
           dockerfile: images/full-alpine-amd64/Dockerfile
+          platforms: linux/amd64
           tags: "latest,${{ env.IMAGE_TAG }}"
 
   full-ubuntu:
-    name: full-ubuntu-amd64
+    name: Build full-ubuntu-amd64
     runs-on: ubuntu-latest
 
     steps:
@@ -158,6 +161,7 @@ jobs:
           registry: ghcr.io
           buildoptions: "--compress --force-rm"
           dockerfile: images/full-ubuntu-amd64/Dockerfile
+          platforms: linux/amd64
           tags: "latest,${{ env.IMAGE_TAG }}"
 
   test-standard-alpine:

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -3,7 +3,7 @@ name: Docker Build and Publish
 on:
   workflow_dispatch:
   push:
-    branches: ["main"]
+    # branches: ["main"]
     paths:
       - "images/**"
   schedule:
@@ -53,6 +53,15 @@ jobs:
           buildoptions: "--compress --force-rm"
           dockerfile: images/standard-alpine-amd64/Dockerfile
           tags: "latest,${{ env.IMAGE_TAG }}"
+
+      - uses: standard-alpine-amd64:${{ github.sha }}
+      - name: Test image
+        run: |
+          terraform version
+          atmos version
+          tflint --version
+          tfsec --version
+          opa version
 
   standard-ubuntu:
     name: standard-ubuntu-amd64

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -56,7 +56,7 @@ jobs:
 
   tests:
     name: Test standard-alpine-amd64
-    runs-on: standard-alpine-amd64:${{ github.sha }}
+    runs-on: ghcr.io/slalombuild/standard-alpine-amd64:${{ github.sha }}
     needs: standard-alpine
     if: ${{ success() }}
     steps:

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -54,22 +54,6 @@ jobs:
           dockerfile: images/standard-alpine-amd64/Dockerfile
           tags: "latest,${{ env.IMAGE_TAG }}"
 
-  tests:
-    name: Test standard-alpine-amd64
-    runs-on: ubuntu-latest
-    container:
-      image: standard-alpine-amd64:${{ github.sha }}
-    needs: standard-alpine
-    if: ${{ success() }}
-    steps:
-      - name: Run each tool
-        run: |
-          terraform version
-          atmos version
-          tflint --version
-          tfsec --version
-          opa version
-
   standard-ubuntu:
     name: standard-ubuntu-amd64
     runs-on: ubuntu-latest
@@ -175,3 +159,22 @@ jobs:
           buildoptions: "--compress --force-rm"
           dockerfile: images/full-ubuntu-amd64/Dockerfile
           tags: "latest,${{ env.IMAGE_TAG }}"
+
+  tests:
+    name: Test standard-alpine-amd64
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/slalombuild/standard-alpine-amd64:${{ github.sha }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    needs: standard-alpine
+    if: ${{ success() }}
+    steps:
+      - name: Run each tool
+        run: |
+          terraform version
+          atmos version
+          tflint --version
+          tfsec --version
+          opa version

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -185,7 +185,7 @@ jobs:
 
   test-full-alpine:
     name: Test full-alpine-amd64
-    runs-on: alpine-latest
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/slalombuild/pe-toolkit-full-alpine-amd64:1.0.${{ github.run_number }}
       credentials:

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -160,15 +160,34 @@ jobs:
           dockerfile: images/full-ubuntu-amd64/Dockerfile
           tags: "latest,${{ env.IMAGE_TAG }}"
 
-  tests:
+  test-standard-alpine:
     name: Test standard-alpine-amd64
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/slalombuild/standard-alpine-amd64:${{ github.sha }}
+      image: ghcr.io/slalombuild/standard-alpine-amd64:1.0.${{ github.run_number }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     needs: standard-alpine
+    if: ${{ success() }}
+    steps:
+      - name: Run each tool
+        run: |
+          terraform version
+          atmos version
+          tflint --version
+          tfsec --version
+          opa version
+
+  test-standard-ubuntu:
+    name: Test standard-ubuntu-amd64
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/slalombuild/standard-ubuntu-amd64:1.0.${{ github.run_number }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    needs: standard-ubuntu
     if: ${{ success() }}
     steps:
       - name: Run each tool

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -168,7 +168,7 @@ jobs:
     name: Test standard-alpine-amd64
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/slalombuild/pe-toolkit-standard-alpine-amd64 :1.0.${{ github.run_number }}
+      image: ghcr.io/slalombuild/pe-toolkit-standard-alpine-amd64:1.0.${{ github.run_number }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -56,7 +56,9 @@ jobs:
 
   tests:
     name: Test standard-alpine-amd64
-    runs-on: standard-alpine-amd64:${{ env.IMAGE_TAG }}
+    runs-on: ubuntu-latest
+    container:
+      image: standard-alpine-amd64:${{ github.sha }}
     needs: standard-alpine
     if: ${{ success() }}
     steps:

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -177,11 +177,11 @@ jobs:
     steps:
       - name: Run each tool
         run: |
-          terraform version
-          atmos version
-          tflint --version
-          tfsec --version
-          opa version
+          figlet terraform && terraform version
+          figlet atmos && atmos version
+          figlet tflint && tflint --version
+          figlet tfsec && tfsec --version
+          figlet opa && opa version
 
   test-full-alpine:
     name: Test full-alpine-amd64
@@ -196,11 +196,11 @@ jobs:
     steps:
       - name: Run each tool
         run: |
-          terraform version
-          atmos version
-          tflint --version
-          tfsec --version
-          opa version
+          figlet terraform && terraform version
+          figlet atmos && atmos version
+          figlet tflint && tflint --version
+          figlet tfsec && tfsec --version
+          figlet opa && opa version
 
   test-standard-ubuntu:
     name: Test standard-ubuntu-amd64
@@ -215,11 +215,11 @@ jobs:
     steps:
       - name: Run each tool
         run: |
-          terraform version
-          atmos version
-          tflint --version
-          tfsec --version
-          opa version
+          figlet terraform && terraform version
+          figlet atmos && atmos version
+          figlet tflint && tflint --version
+          figlet tfsec && tfsec --version
+          figlet opa && opa version
 
   test-full-ubuntu:
     name: Test full-ubuntu-amd64
@@ -234,8 +234,8 @@ jobs:
     steps:
       - name: Run each tool
         run: |
-          terraform version
-          atmos version
-          tflint --version
-          tfsec --version
-          opa version
+          figlet terraform && terraform version
+          figlet atmos && atmos version
+          figlet tflint && tflint --version
+          figlet tfsec && tfsec --version
+          figlet opa && opa version

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -54,8 +54,11 @@ jobs:
           dockerfile: images/standard-alpine-amd64/Dockerfile
           tags: "latest,${{ env.IMAGE_TAG }}"
 
-      - uses: standard-alpine-amd64:${{ github.sha }}
-      - name: Test image
+  tests:
+    name: Test standard-alpine-amd64
+    runs-on: standard-alpine-amd64:${{ github.sha }}
+    steps:
+      - name: Tests
         run: |
           terraform version
           atmos version

--- a/README.md
+++ b/README.md
@@ -42,7 +42,20 @@ Sure, go ahead and submit a PR. Some considerations when adding a tool -
 - If the tool significantly increases the image size, is it something we want in our toolkit, or something we'd run in a pipeline using an official image for the tool?
 - Standard is intended to be lightweight, mainly used in pipelines, and Full is intended for development environments
 
-#### Which versions do we use?
+#### I've made some changes and they don't work, how do I debug the problem?
+
+1. Attempt to build the problematic image. Change to the relevant folder containing a `Dockerfile` under `images` and run 
+   ```bash
+   docker build -t test:latest .   
+   ```
+2. View the output for any errors.
+3. If the container image builds successfully, start a shell in the container using 
+   ```bash
+   docker run --rm -it --entrypoint /bin/bash test
+   ``` 
+   and perform further debugging steps.
+
+#### Which versions of binaries do we use?
 
 We use the latest version of each tool at the time of building of the image.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ docker pull ghcr.io/slalombuild/pe-toolkit-standard-ubuntu-amd64:latest
 
 | Standard | Full |
 | --- | --- |
-| `terraform`<br/> `atmos`<br/> `curl`<br/> `bash`<br/> `jq`<br/> `yq`<br/> `figlet`<br/> `unzip`<br/> `zip`<br/> `git`<br/> `shellcheck`<br/> `nano`<br/> `tflint`<br/> `tfsec`<br/>| _everything in standard_<br/>`hadolint`<br/>`terraform-docs`<br/>`node` and `npm`<br/>`python` and `pip`<br/>`go`<br/> |
+| `terraform`<br/> `atmos`<br/> `curl`<br/> `bash`<br/> `jq`<br/> `yq`<br/> `figlet`<br/> `unzip`<br/> `zip`<br/> `git`<br/> `shellcheck`<br/> `nano`<br/> `tflint`<br/> `tfsec`<br/> `opa`<br/>| _everything in standard_<br/>`hadolint`<br/>`terraform-docs`<br/>`node` and `npm`<br/>`python` and `pip`<br/>`go`<br/> |
 
 #### I'd like the image(s) to include x, can I add it?
 

--- a/images/full-alpine-amd64/Dockerfile
+++ b/images/full-alpine-amd64/Dockerfile
@@ -83,4 +83,4 @@ RUN export tfsecrelease="$(curl -Ls -o /dev/null -w %{url_effective} "https://gi
 # Install Open Policy Agent (https://openpolicyagent.org)
 RUN curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64 \
   && chmod +x opa \
-  && mv opa /usr/local/bin/
+  && mv opa /usr/local/bin/opa

--- a/images/full-alpine-amd64/Dockerfile
+++ b/images/full-alpine-amd64/Dockerfile
@@ -81,6 +81,6 @@ RUN export tfsecrelease="$(curl -Ls -o /dev/null -w %{url_effective} "https://gi
   && mv tfsec-linux-amd64 /usr/local/bin/tfsec
 
 # Install Open Policy Agent (https://openpolicyagent.org)
-RUN curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64 \
+RUN curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static \
   && chmod +x opa \
   && mv opa /usr/local/bin/opa

--- a/images/full-alpine-amd64/Dockerfile
+++ b/images/full-alpine-amd64/Dockerfile
@@ -33,50 +33,54 @@ RUN export tfrelease="$(curl -Ls -o /dev/null -w %{url_effective} https://github
   && echo "Installing terraform v${tfrelease}" \
   && wget https://releases.hashicorp.com/terraform/${tfrelease}/terraform_${tfrelease}_linux_amd64.zip \
   && unzip terraform_${tfrelease}_linux_amd64.zip \
-  && mv terraform /usr/bin/terraform \
+  && chmod +x terraform \
+  && mv terraform /usr/local/bin/terraform \
   && rm terraform_${tfrelease}_linux_amd64.zip
 
 # Install atmos (https://github.com/cloudposse/atmos)
 RUN export atmosrelease="$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/cloudposse/atmos/releases/latest | awk -F / '{print substr($NF,2);}')" \
   && echo "Installing atmos v${atmosrelease}" \
   && wget https://github.com/cloudposse/atmos/releases/download/v${atmosrelease}/atmos_${atmosrelease}_linux_amd64 \
-  && mv atmos_${atmosrelease}_linux_amd64 /usr/bin/atmos \
-  && chmod +x /usr/bin/atmos
+  && chmod +x atmos_${atmosrelease}_linux_amd64 \
+  && mv atmos_${atmosrelease}_linux_amd64 /usr/local/bin/atmos
 
 # Install terraform-docs
 RUN export tfdocsrelease="$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/terraform-docs/terraform-docs/releases/latest | awk -F / '{print substr($NF,2);}')" \
   && echo "Installing terraform-docs v${tfdocsrelease}" \
   && wget https://github.com/terraform-docs/terraform-docs/releases/download/v${tfdocsrelease}/terraform-docs-v${tfdocsrelease}-linux-amd64.tar.gz \
-  && tar -xzf terraform-docs-v${tfdocsrelease}-linux-amd64.tar.gz -C /usr/bin terraform-docs \
-  && rm terraform-docs-v${tfdocsrelease}-linux-amd64.tar.gz \
-  && chmod +x /usr/bin/terraform-docs
+  && tar -xzf terraform-docs-v${tfdocsrelease}-linux-amd64.tar.gz -C /usr/local/bin terraform-docs \
+  && chmod +x /usr/local/bin/terraform-docs \
+  && rm terraform-docs-v${tfdocsrelease}-linux-amd64.tar.gz
 
 # Install Packer https://github.com/hashicorp/packer()
 ARG packer_version=1.8.5
 ARG packer_zip_url=https://releases.hashicorp.com/packer/${packer_version}/packer_${packer_version}_linux_amd64.zip
 RUN wget -nv ${packer_zip_url} \
-  && unzip -d /usr/bin packer_${packer_version}_linux_amd64.zip \
+  && unzip -d /usr/local/bin packer_${packer_version}_linux_amd64.zip \
   && rm packer_${packer_version}_linux_amd64.zip
 
 # Install hadolint (https://github.com/hadolint/hadolint)
 ARG hadolint_version=2.12.0
 RUN wget -nv https://github.com/hadolint/hadolint/releases/download/v${hadolint_version}/hadolint-Linux-x86_64 \
   && mv hadolint-Linux-x86_64 /usr/local/bin/hadolint \
-  && chmod 755 /usr/local/bin/hadolint
+  && chmod +x /usr/local/bin/hadolint
 
 # Install tflint (https://github.com/terraform-linters/tflint)
 RUN export tflintrelease="$(curl -Ls -o /dev/null -w %{url_effective} "https://github.com/terraform-linters/tflint/releases/latest" | awk -F / '{print substr($NF,2);}')" \
   && echo "Installing tflint v${tflintrelease}" \
   && wget https://github.com/terraform-linters/tflint/releases/download/v${tflintrelease}/tflint_linux_amd64.zip \
-  && unzip tflint_linux_amd64.zip \
-  && mv tflint /usr/bin/tflint \
-  && chmod +x /usr/bin/tflint
+  && unzip -d /usr/local/bin tflint_linux_amd64.zip \
+  && chmod +x /usr/local/bin/tflint \
+  && rm tflint_linux_amd64.zip
 
 # Install tfsec (https://github.com/aquasecurity/tfsec)
 RUN export tfsecrelease="$(curl -Ls -o /dev/null -w %{url_effective} "https://github.com/aquasecurity/tfsec/releases/latest" | awk -F / '{print substr($NF,2);}')" \
   && echo "Installing tfsec v${tfsecrelease}" \
   && wget https://github.com/aquasecurity/tfsec/releases/download/v${tfsecrelease}/tfsec-linux-amd64 \
-  && mv tfsec-linux-amd64 /usr/bin/tfsec \
-  && chmod +x /usr/bin/tfsec
+  && chmod +x tfsec-linux-amd64 \
+  && mv tfsec-linux-amd64 /usr/local/bin/tfsec
 
-
+# Install Open Policy Agent (https://openpolicyagent.org)
+RUN curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64 \
+  && chmod +x opa \
+  && mv opa /usr/local/bin/

--- a/images/full-ubuntu-amd64/Dockerfile
+++ b/images/full-ubuntu-amd64/Dockerfile
@@ -81,4 +81,4 @@ RUN export tfsecrelease="$(curl -Ls -o /dev/null -w %{url_effective} "https://gi
 # Install Open Policy Agent (https://openpolicyagent.org)
 RUN curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64 \
   && chmod +x opa \
-  && mv opa /usr/local/bin/
+  && mv opa /usr/local/bin/opa

--- a/images/full-ubuntu-amd64/Dockerfile
+++ b/images/full-ubuntu-amd64/Dockerfile
@@ -31,27 +31,24 @@ RUN export tfrelease="$(curl -Ls -o /dev/null -w %{url_effective} https://github
   && echo "Installing terraform v${tfrelease}" \
   && wget https://releases.hashicorp.com/terraform/${tfrelease}/terraform_${tfrelease}_linux_amd64.zip \
   && unzip terraform_${tfrelease}_linux_amd64.zip \
-  && mv terraform /usr/bin/terraform \
+  && chmod +x terraform \
+  && mv terraform /usr/local/bin/terraform \
   && rm terraform_${tfrelease}_linux_amd64.zip
 
 # Install atmos (https://github.com/cloudposse/atmos)
 RUN export atmosrelease="$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/cloudposse/atmos/releases/latest | awk -F / '{print substr($NF,2);}')" \
   && echo "Installing atmos v${atmosrelease}" \
   && wget https://github.com/cloudposse/atmos/releases/download/v${atmosrelease}/atmos_${atmosrelease}_linux_amd64 \
-  && mv atmos_${atmosrelease}_linux_amd64 /usr/bin/atmos \
-  && chmod +x /usr/bin/atmos
+  && chmod +x atmos_${atmosrelease}_linux_amd64 \
+  && mv atmos_${atmosrelease}_linux_amd64 /usr/local/bin/atmos
 
 # Install terraform-docs
 RUN export tfdocsrelease="$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/terraform-docs/terraform-docs/releases/latest | awk -F / '{print substr($NF,2);}')" \
   && echo "Installing terraform-docs v${tfdocsrelease}" \
   && wget https://github.com/terraform-docs/terraform-docs/releases/download/v${tfdocsrelease}/terraform-docs-v${tfdocsrelease}-linux-amd64.tar.gz \
-  && tar -xzf terraform-docs-v${tfdocsrelease}-linux-amd64.tar.gz -C /usr/bin terraform-docs \
-  && rm terraform-docs-v${tfdocsrelease}-linux-amd64.tar.gz \
-  && chmod +x /usr/bin/terraform-docs
-
-# Install checkov
-RUN export checkovrelease="$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/bridgecrewio/checkov/releases/latest | awk -F / '{print substr($NF,1);}')" \
-  && pip install checkov==${checkovrelease}
+  && tar -xzf terraform-docs-v${tfdocsrelease}-linux-amd64.tar.gz -C /usr/local/bin terraform-docs \
+  && chmod +x /usr/local/bin/terraform-docs \
+  && rm terraform-docs-v${tfdocsrelease}-linux-amd64.tar.gz
 
 # Install Packer https://github.com/hashicorp/packer()
 ARG packer_version=1.8.5
@@ -64,19 +61,24 @@ RUN wget -nv ${packer_zip_url} \
 ARG hadolint_version=2.12.0
 RUN wget -nv https://github.com/hadolint/hadolint/releases/download/v${hadolint_version}/hadolint-Linux-x86_64 \
   && mv hadolint-Linux-x86_64 /usr/local/bin/hadolint \
-  && chmod 755 /usr/local/bin/hadolint
+  && chmod +x /usr/local/bin/hadolint
 
 # Install tflint (https://github.com/terraform-linters/tflint)
 RUN export tflintrelease="$(curl -Ls -o /dev/null -w %{url_effective} "https://github.com/terraform-linters/tflint/releases/latest" | awk -F / '{print substr($NF,2);}')" \
   && echo "Installing tflint v${tflintrelease}" \
   && wget https://github.com/terraform-linters/tflint/releases/download/v${tflintrelease}/tflint_linux_amd64.zip \
-  && unzip tflint_linux_amd64.zip \
-  && mv tflint /usr/bin/tflint \
-  && chmod +x /usr/bin/tflint
+  && unzip -d /usr/local/bin tflint_linux_amd64.zip \
+  && chmod +x /usr/local/bin/tflint \
+  && rm tflint_linux_amd64.zip
 
 # Install tfsec (https://github.com/aquasecurity/tfsec)
 RUN export tfsecrelease="$(curl -Ls -o /dev/null -w %{url_effective} "https://github.com/aquasecurity/tfsec/releases/latest" | awk -F / '{print substr($NF,2);}')" \
   && echo "Installing tfsec v${tfsecrelease}" \
   && wget https://github.com/aquasecurity/tfsec/releases/download/v${tfsecrelease}/tfsec-linux-amd64 \
-  && mv tfsec-linux-amd64 /usr/bin/tfsec \
-  && chmod +x /usr/bin/tfsec
+  && chmod +x tfsec-linux-amd64 \
+  && mv tfsec-linux-amd64 /usr/local/bin/tfsec
+
+# Install Open Policy Agent (https://openpolicyagent.org)
+RUN curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64 \
+  && chmod +x opa \
+  && mv opa /usr/local/bin/

--- a/images/standard-alpine-amd64/Dockerfile
+++ b/images/standard-alpine-amd64/Dockerfile
@@ -47,6 +47,6 @@ RUN export tfsecrelease="$(curl -Ls -o /dev/null -w %{url_effective} "https://gi
   && mv tfsec-linux-amd64 /usr/local/bin/tfsec
 
 # Install Open Policy Agent (https://openpolicyagent.org)
-RUN curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64 \
+RUN curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static \
   && chmod +x opa \
   && mv opa /usr/local/bin/opa

--- a/images/standard-alpine-amd64/Dockerfile
+++ b/images/standard-alpine-amd64/Dockerfile
@@ -20,27 +20,33 @@ RUN export tfrelease="$(curl -Ls -o /dev/null -w %{url_effective} https://github
   && echo "Installing terraform v${tfrelease}" \
   && wget https://releases.hashicorp.com/terraform/${tfrelease}/terraform_${tfrelease}_linux_amd64.zip \
   && unzip terraform_${tfrelease}_linux_amd64.zip \
-  && mv terraform /usr/bin/terraform \
+  && chmod +x terraform \
+  && mv terraform /usr/local/bin/terraform \
   && rm terraform_${tfrelease}_linux_amd64.zip
 
 # Install atmos (https://github.com/cloudposse/atmos)
 RUN export atmosrelease="$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/cloudposse/atmos/releases/latest | awk -F / '{print substr($NF,2);}')" \
   && echo "Installing atmos v${atmosrelease}" \
   && wget https://github.com/cloudposse/atmos/releases/download/v${atmosrelease}/atmos_${atmosrelease}_linux_amd64 \
-  && mv atmos_${atmosrelease}_linux_amd64 /usr/bin/atmos \
-  && chmod +x /usr/bin/atmos
+  && chmod +x atmos_${atmosrelease}_linux_amd64 \
+  && mv atmos_${atmosrelease}_linux_amd64 /usr/local/bin/atmos
 
 # Install tflint (https://github.com/terraform-linters/tflint)
 RUN export tflintrelease="$(curl -Ls -o /dev/null -w %{url_effective} "https://github.com/terraform-linters/tflint/releases/latest" | awk -F / '{print substr($NF,2);}')" \
   && echo "Installing tflint v${tflintrelease}" \
   && wget https://github.com/terraform-linters/tflint/releases/download/v${tflintrelease}/tflint_linux_amd64.zip \
-  && unzip tflint_linux_amd64.zip \
-  && mv tflint /usr/bin/tflint \
-  && chmod +x /usr/bin/tflint
+  && unzip -d /usr/local/bin tflint_linux_amd64.zip \
+  && chmod +x /usr/local/bin/tflint \
+  && rm tflint_linux_amd64.zip
 
 # Install tfsec (https://github.com/aquasecurity/tfsec)
 RUN export tfsecrelease="$(curl -Ls -o /dev/null -w %{url_effective} "https://github.com/aquasecurity/tfsec/releases/latest" | awk -F / '{print substr($NF,2);}')" \
   && echo "Installing tfsec v${tfsecrelease}" \
   && wget https://github.com/aquasecurity/tfsec/releases/download/v${tfsecrelease}/tfsec-linux-amd64 \
-  && mv tfsec-linux-amd64 /usr/bin/tfsec \
-  && chmod +x /usr/bin/tfsec
+  && chmod +x tfsec-linux-amd64 \
+  && mv tfsec-linux-amd64 /usr/local/bin/tfsec
+
+# Install Open Policy Agent (https://openpolicyagent.org)
+RUN curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64 \
+  && chmod +x opa \
+  && mv opa /usr/local/bin/

--- a/images/standard-alpine-amd64/Dockerfile
+++ b/images/standard-alpine-amd64/Dockerfile
@@ -49,4 +49,4 @@ RUN export tfsecrelease="$(curl -Ls -o /dev/null -w %{url_effective} "https://gi
 # Install Open Policy Agent (https://openpolicyagent.org)
 RUN curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64 \
   && chmod +x opa \
-  && mv opa /usr/local/bin/
+  && mv opa /usr/local/bin/opa

--- a/images/standard-ubuntu-amd64/Dockerfile
+++ b/images/standard-ubuntu-amd64/Dockerfile
@@ -21,28 +21,33 @@ RUN export tfrelease="$(curl -Ls -o /dev/null -w %{url_effective} https://github
   && echo "Installing terraform v${tfrelease}" \
   && wget https://releases.hashicorp.com/terraform/${tfrelease}/terraform_${tfrelease}_linux_amd64.zip \
   && unzip terraform_${tfrelease}_linux_amd64.zip \
-  && mv terraform /usr/bin/terraform \
+  && chmod +x terraform \
+  && mv terraform /usr/local/bin/terraform \
   && rm terraform_${tfrelease}_linux_amd64.zip
 
 # Install atmos (https://github.com/cloudposse/atmos)
 RUN export atmosrelease="$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/cloudposse/atmos/releases/latest | awk -F / '{print substr($NF,2);}')" \
   && echo "Installing atmos v${atmosrelease}" \
   && wget https://github.com/cloudposse/atmos/releases/download/v${atmosrelease}/atmos_${atmosrelease}_linux_amd64 \
-  && mv atmos_${atmosrelease}_linux_amd64 /usr/bin/atmos \
-  && chmod +x /usr/bin/atmos
+  && chmod +x atmos_${atmosrelease}_linux_amd64 \
+  && mv atmos_${atmosrelease}_linux_amd64 /usr/local/bin/atmos
 
 # Install tflint (https://github.com/terraform-linters/tflint)
 RUN export tflintrelease="$(curl -Ls -o /dev/null -w %{url_effective} "https://github.com/terraform-linters/tflint/releases/latest" | awk -F / '{print substr($NF,2);}')" \
   && echo "Installing tflint v${tflintrelease}" \
   && wget https://github.com/terraform-linters/tflint/releases/download/v${tflintrelease}/tflint_linux_amd64.zip \
-  && unzip tflint_linux_amd64.zip \
-  && mv tflint /usr/bin/tflint \
-  && chmod +x /usr/bin/tflint
+  && unzip -d /usr/local/bin tflint_linux_amd64.zip \
+  && chmod +x /usr/local/bin/tflint \
+  && rm tflint_linux_amd64.zip
 
 # Install tfsec (https://github.com/aquasecurity/tfsec)
 RUN export tfsecrelease="$(curl -Ls -o /dev/null -w %{url_effective} "https://github.com/aquasecurity/tfsec/releases/latest" | awk -F / '{print substr($NF,2);}')" \
   && echo "Installing tfsec v${tfsecrelease}" \
   && wget https://github.com/aquasecurity/tfsec/releases/download/v${tfsecrelease}/tfsec-linux-amd64 \
-  && mv tfsec-linux-amd64 /usr/bin/tfsec \
-  && chmod +x /usr/bin/tfsec
+  && chmod +x tfsec-linux-amd64 \
+  && mv tfsec-linux-amd64 /usr/local/bin/tfsec
 
+# Install Open Policy Agent (https://openpolicyagent.org)
+RUN curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64 \
+  && chmod +x opa \
+  && mv opa /usr/local/bin/

--- a/images/standard-ubuntu-amd64/Dockerfile
+++ b/images/standard-ubuntu-amd64/Dockerfile
@@ -50,4 +50,4 @@ RUN export tfsecrelease="$(curl -Ls -o /dev/null -w %{url_effective} "https://gi
 # Install Open Policy Agent (https://openpolicyagent.org)
 RUN curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64 \
   && chmod +x opa \
-  && mv opa /usr/local/bin/
+  && mv opa /usr/local/bin/opa


### PR DESCRIPTION
* Added `opa` to the standard and full images (it’s increasingly being requested)
* Added tests to the build-and-publish pipeline to ensure that binaries are successfully installed (they actually caught an issue with `opa` not working correctly on alpine)
* MINOR: binaries that were installed to `/usr/bin` are now installed to `/usr/bin/local`