### PR TITLE
Fixed failing pipelines

### DIFF
--- a/images/dockerfile-full-alpine
+++ b/images/dockerfile-full-alpine
@@ -79,7 +79,7 @@ RUN case ${TARGETPLATFORM} in \
   *)              ARCHITECTURE=amd64   ;; \
   esac \
   && echo "Installing opa (${ARCHITECTURE})" \
-  && curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_${ARCHITECTURE}_static \
+  && wget -O opa https://openpolicyagent.org/downloads/latest/opa_linux_${ARCHITECTURE}_static \
   && chmod +x opa \
   && mv opa /usr/local/bin/opa
 

--- a/images/dockerfile-full-ubuntu
+++ b/images/dockerfile-full-ubuntu
@@ -83,7 +83,7 @@ RUN case ${TARGETPLATFORM} in \
   *)              ARCHITECTURE=amd64   ;; \
   esac \
   && echo "Installing opa (${ARCHITECTURE})" \
-  && curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_${ARCHITECTURE}_static \
+  && wget -O opa https://openpolicyagent.org/downloads/latest/opa_linux_${ARCHITECTURE}_static \
   && chmod +x opa \
   && mv opa /usr/local/bin/opa
 

--- a/images/dockerfile-standard-alpine
+++ b/images/dockerfile-standard-alpine
@@ -70,6 +70,6 @@ RUN case ${TARGETPLATFORM} in \
   *)              ARCHITECTURE=amd64   ;; \
   esac \
   && echo "Installing opa (${ARCHITECTURE})" \
-  && curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_${ARCHITECTURE}_static \
+  && wget -O opa https://openpolicyagent.org/downloads/latest/opa_linux_${ARCHITECTURE}_static \
   && chmod +x opa \
   && mv opa /usr/local/bin/opa

--- a/images/dockerfile-standard-ubuntu
+++ b/images/dockerfile-standard-ubuntu
@@ -71,6 +71,6 @@ RUN case ${TARGETPLATFORM} in \
   *)              ARCHITECTURE=amd64   ;; \
   esac \
   && echo "Installing opa (${ARCHITECTURE})" \
-  && curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_${ARCHITECTURE}_static \
+  && wget -O opa https://openpolicyagent.org/downloads/latest/opa_linux_${ARCHITECTURE}_static \
   && chmod +x opa \
   && mv opa /usr/local/bin/opa


### PR DESCRIPTION
## What
* Replaced `curl` command with `wget` to fix failing pipelines.

## Why
* `curl` usage in pipelines deprecated

